### PR TITLE
Fix Webhooks is not a Resource instance error

### DIFF
--- a/src/Resources/Webhooks.php
+++ b/src/Resources/Webhooks.php
@@ -5,10 +5,21 @@ namespace Oktave\Resources;
 use Oktave\Client;
 use Oktave\Exceptions\InvalidConfigurationException;
 use Oktave\Exceptions\ValidationException;
+use Oktave\Resource;
 
-class Webhooks
+class Webhooks extends Resource
 {
     const HMAC_HASH_ALGO = 'sha256';
+
+    /**
+     * {@inheritDoc}
+     */
+    public $resourceCollection = 'webhooks';
+
+    /**
+     * {@inheritDoc}
+     */
+    public $resource = 'webhook';
 
     /**
      * @var Client

--- a/tests/Resources/WebhooksTest.php
+++ b/tests/Resources/WebhooksTest.php
@@ -8,6 +8,13 @@ use PHPUnit\Framework\TestCase;
 
 class WebhooksTest extends TestCase
 {
+    public function testWebhooksCanBeRetrievedFromClient(): void
+    {
+        $client = new Oktave\Client();
+
+        $this->assertInstanceOf(Oktave\Resources\Webhooks::class, $client->webhooks);
+    }
+
     public function testThrowExceptionIfNoWebhookSecretProvided(): void
     {
         $client = Mockery::mock(Oktave\Client::class);


### PR DESCRIPTION
This PR fix the error which occurs when trying to retrieve `$client->webhooks`, because `Webhooks` class was not a instance of `Resource`.